### PR TITLE
remove parking_lot v0.11 dependency

### DIFF
--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -26,10 +26,15 @@ tracing = "0.1.26"
 hyper = "0.14.0"
 tokio = { version = "1.6.0", features = ["time"] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] } # work around https://github.com/tomaka/wasm-timer/issues/14
-wasm-timer = "0.2.5"
-getrandom = { version = "0.2.0", features = ["js"] }
+# Note: Supporting WASM requires a dependency on `wasm-timer` which pulls in `parking_lot v0.11`,
+# which is an old version. Ideally we could update `wasm-timer` to use `parking_lot v0.12` but that
+# crate is unmaintained. Instead of forking `wasm-timer` and this crate, we just fork this crate
+# and remove the dependencies since we don't need to support WASM.
+# 
+# [target.'cfg(target_arch = "wasm32")'.dependencies]
+# parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] } # work around https://github.com/tomaka/wasm-timer/issues/14
+# wasm-timer = "0.2.5"
+# getrandom = { version = "0.2.0", features = ["js"] }
 
 [dev-dependencies]
 paste = "1.0.0"


### PR DESCRIPTION
Currently the WASM support relies on `wasm-timer` which pulls in `parking_lot v0.11`, the most current version of parking_lot is v0.12. Ideally we fork `wasm-timer` and update parking_lot, but that crate does not appear to be maintained. So instead of forking `wasm-timer` and patching the transitive dependency, we update `reqwest-middleware` and just remove the WASM dependencies since we don't need WASM support.